### PR TITLE
Adding copy module functionality

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,9 @@ munin_node_allowed_ips:
 munin_plugin_src_path: /usr/share/munin/plugins/
 munin_plugin_dest_path: /etc/munin/plugins/
 
+# List of munin modules to copy to the server.
+munin_modules: []
+
 # List of munin plugins to enable.
 munin_node_plugins: []
   # - name: uptime

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,16 @@
     mode: 0644
   notify: restart munin-node
 
+- name: Copy modules onto server.
+  copy:
+    src="{{ item.source }}"
+    dest="{{ item.destination }}"
+    owner="{{ item.owner }}"
+    group="{{ item.group }}"
+    mode="{{ item.mode }}"
+  with_items: "{{ munin_modules }}"
+  notify: restart munin-node
+
 - name: Enable additional plugins.
   file:
     path: "{{ munin_plugin_dest_path }}{{ item.name }}"


### PR DESCRIPTION
Adding copy functionality to external munin role because it is constantly reused in our monitoring role by different servers. 